### PR TITLE
Add multiexpand API with pipeline support, falling back to connection re-use.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: .
+  specs:
+    rangeclient (0.0.13)
+      net-http-pipeline (~> 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    net-http-pipeline (1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rangeclient!

--- a/lib/rangeclient.rb
+++ b/lib/rangeclient.rb
@@ -2,6 +2,7 @@
 
 require 'rubygems'
 require 'net/http'
+require 'net/http/pipeline'
 require 'uri'
 
 class Range::Client
@@ -38,6 +39,33 @@ class Range::Client
     resp = http.request(req)
     @rangeexception = resp['rangeexception']
     return resp.body.split "\n"
+  end
+
+  def multiexpand(*args)
+    result = []
+    http = Net::HTTP.new(@host, @port)
+    http.read_timeout = @timeout
+    http.use_ssl = @ssl
+    http.start do |http|
+      reqs = args.map do |arg|
+        escaped_arg = URI.escape arg
+        req = Net::HTTP::Get.new('/range/list?' + escaped_arg)
+      end
+      begin
+        http.pipeline(reqs) do |resp|
+          @rangeexception ||= resp['rangeexception']
+          result << resp.body.split("\n")
+        end
+      rescue Net::HTTP::Pipeline::PersistenceError
+        # Pipelining not supported, fallback to sequential requests.
+        reqs.each do |req|
+          resp = http.request(req)
+          @rangeexception ||= resp['rangeexception']
+          result << resp.body.split("\n")
+        end
+      end
+    end
+    result
   end
 
 

--- a/rangeclient.gemspec
+++ b/rangeclient.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + Dir.glob("bin/*") + %w(README.md)
   s.extra_rdoc_files = ["LICENSE.md"]
   s.rdoc_options = ["--charset=UTF-8"]
+  s.add_dependency 'net-http-pipeline', '~> 1.0', '>= 1.0.1'
 end
 


### PR DESCRIPTION
@eam at the very least, WDYT about adding `multiexpand` method? If we want to add new endpoint to server in future we can switch out the implementation.

This change doesn't help that much (really we want SPDY/HTTP2 for multiplexing), but is better than nothing. I half-heartedly tried to run some benchmarks but response times are just all over the map anyways that it overshadowed any improvement with my short run times. I did confirm it was working with debug logging.

For reference, grange supports pipelining, crange doesn't. (that's just what the out-of-the-box HTTP servers are doing, I didn't change either of them.)
