### PR TITLE
URI.escape has been obsolete for at least 10 years (since ruby-1.9.2)

### DIFF
--- a/lib/rangeclient.rb
+++ b/lib/rangeclient.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems'
 require 'net/http'
-require 'uri'
+require 'erb'
 
 class Range::Client
   attr_accessor :host, :port, :timeout, :rangeexception
@@ -37,7 +37,7 @@ class Range::Client
   end
 
   def expand(arg)
-    escaped_arg = URI.escape arg
+    escaped_arg = ERB::Util.url_encode arg
     http = Net::HTTP.new(@host, @port)
     http.read_timeout = @timeout
     if @ssl

--- a/lib/rangeclient.rb
+++ b/lib/rangeclient.rb
@@ -37,7 +37,7 @@ class Range::Client
   end
 
   def expand(arg)
-    escaped_arg = ERB::Util.url_encode arg
+    escaped_arg = URI.encode_www_form_component arg
     http = Net::HTTP.new(@host, @port)
     http.read_timeout = @timeout
     if @ssl

--- a/lib/rangeclient.rb
+++ b/lib/rangeclient.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems'
 require 'net/http'
-require 'erb'
+require 'uri'
 
 class Range::Client
   attr_accessor :host, :port, :timeout, :rangeexception

--- a/rangeclient.gemspec
+++ b/rangeclient.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "rangeclient"
-  s.version     = "0.0.18"
+  s.version     = "0.0.19"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Evan Miller"]
   s.email       = ["evan@squareup.com"]


### PR DESCRIPTION
Simple fix to get rid of the warning that prints out using ruby-2.7.2 and later:
```
/Users/tboss/.rvm/gems/ruby-2.7.2/gems/rangeclient-0.0.18/lib/rangeclient.rb:37: warning: URI.escape is obsolete
```